### PR TITLE
Disable API browser

### DIFF
--- a/govgrant/settings.py
+++ b/govgrant/settings.py
@@ -120,3 +120,14 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
 STATIC_URL = '/static/'
+
+
+# Django Rest Framework
+# https://www.django-rest-framework.org/api-guide/settings/
+
+REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        # 'rest_framework.renderers.BrowsableAPIRenderer',
+    ),
+}


### PR DESCRIPTION
This PR removes the default API browser. While it is useful for exploring the endpoints, some modifications made in the app were not optimised for the built-in API browser, which will cause confusion to users if left enabled by default.